### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/digitalservicebund/github-actions-linter/security/code-scanning/1](https://github.com/digitalservicebund/github-actions-linter/security/code-scanning/1)

**General fix:**  
Add a `permissions` block to the workflow yaml file, setting it to the minimum privilege required. For a standard Node.js CI flow (checkout + test + lint), this is typically `contents: read`, which allows actions to fetch code but not push changes or interact with issues/PRs.

**Best implementation:**  
Insert a `permissions: contents: read` block near the top of the workflow file, either at the root level (applies to all jobs) or within each job if finer control is needed. Root level is preferred for maintainability in simple workflows like this.

**Where to change:**  
Edit `.github/workflows/ci.yml` to add a `permissions: contents: read` block directly below the workflow name, before the `on:` key (i.e., after line 1).

**Methods/imports/definitions needed:**  
No additional methods, imports, or dependencies are needed—just a simple YAML edit.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
